### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     },
     "require": {
         "php": "^7.0",
-        "illuminate/database": "~5.5",
-        "illuminate/support": "~5.5"
+        "illuminate/database": "5.5.*",
+        "illuminate/support": "5.5.*"
     },
     "require-dev": {
         "orchestra/testbench": "~3.6@dev",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.