### PR TITLE
Fix Rating Average So It Takes Only Rating Into Consideration

### DIFF
--- a/src/Traits/Rate/Rateable.php
+++ b/src/Traits/Rate/Rateable.php
@@ -13,7 +13,7 @@ trait Rateable
 
     public function ratingsAvg()
     {
-        return $this->ratings()->where('type', 'rate')->avg('value');
+        return round($this->ratings()->where('type', 'rate')->avg('value'), 2);
     }
 
     public function ratingsCount()

--- a/src/Traits/Rate/Rateable.php
+++ b/src/Traits/Rate/Rateable.php
@@ -13,7 +13,7 @@ trait Rateable
 
     public function ratingsAvg()
     {
-        return round($this->ratings()->where('type', 'rate')->avg('value'), 2);
+        return $this->ratings()->where('type', 'rate')->avg('value');
     }
 
     public function ratingsCount()

--- a/src/Traits/Rate/Rateable.php
+++ b/src/Traits/Rate/Rateable.php
@@ -13,7 +13,7 @@ trait Rateable
 
     public function ratingsAvg()
     {
-        return $this->ratings()->avg('value');
+        return $this->ratings()->where('type', 'rate')->avg('value');
     }
 
     public function ratingsCount()


### PR DESCRIPTION
Currently `ratingsAvg()` was taking likes & dislikes into consideration when calculating the average rating for a specific model which is wrong.